### PR TITLE
Fix COCONUT_API_KEY env-name

### DIFF
--- a/src/Coconut.php
+++ b/src/Coconut.php
@@ -9,7 +9,7 @@ class Coconut {
     $coconut_url = self::COCONUT_URL;
 
     if(!$api_key) {
-      $api_key = getenv("HEYWATCH_API_KEY");
+      $api_key = getenv("COCONUT_API_KEY");
     }
 
     if($url = getenv("COCONUT_URL"))


### PR DESCRIPTION
seems like `HEYWATCH_API_KEY` was from the legacy project, also `COCONUT_API_KEY` is documented here: http://coconut.co/php