### PR TITLE
Do not use dynamic properties: it's deprecated in PHP 8.2

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -10,7 +10,10 @@ class Client
     public $endpoint;
     public $storage;
     public $notification;
-    
+    public $api;
+    public $job;
+    public $metadata;
+
     function __construct($api_key, $config = [])
     {
         $this->api_key = $api_key;


### PR DESCRIPTION
Refs:
 - https://www.php.net/manual/en/migration82.deprecated.php#migration82.deprecated.core.dynamic-properties
 - https://php.watch/versions/8.2/dynamic-properties-deprecated

Closes #14