### PR TITLE
Stop using dynamically declare properties in Client

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -10,6 +10,9 @@ class Client
     public $endpoint;
     public $storage;
     public $notification;
+    public $job;
+    public $api;
+    public $metadata;
     
     function __construct($api_key, $config = [])
     {


### PR DESCRIPTION
It is not a good practice.